### PR TITLE
Disable "Place my order" button if no items selected.

### DIFF
--- a/pmo/order/order.js
+++ b/pmo/order/order.js
@@ -35,6 +35,18 @@ export const ViewModel = Map.extend({
       Value: Object
     },
     /**
+     * @property {Boolean} canPlaceOrder
+     *
+     * A flag to enable / disable the "Place my order" button.
+     */
+    canPlaceOrder: {
+      type: 'boolean',
+      get() {
+        let items = this.attr('order.items');
+        return items.attr('length');
+      }
+    },
+    /**
      * @property {can.Deferred} restaurant
      *
      * The restaurant instance as a Deferred.

--- a/pmo/order/order.stache
+++ b/pmo/order/order.stache
@@ -67,6 +67,7 @@
               <div class="loading"></div>
             {{else}}
               <button type="submit" class="btn">Place My Order!</button>
+              <button type="submit" {{^if canPlaceOrder}}disabled{{/if}} class="btn">Place My Order!</button>
             {{/if}}
           {{/if}}
         </div>

--- a/pmo/order/order_test.js
+++ b/pmo/order/order_test.js
@@ -11,6 +11,24 @@ test('Default order is initialized', () => {
   ok(vm.attr('order') instanceof Order);
 });
 
+test('canPlaceOrder indicates whether the order has items', () => {
+  let vm = new ViewModel();
+  let items = vm.attr('order.items');
+
+  let item = {
+    name: 'pabellon criollo',
+    price: 35.90
+  };
+
+  ok(!items.attr('length'), 'order has no items');
+  ok(!vm.attr('canPlaceOrder'), 'user can not place order without items');
+
+  items.push(item);
+
+  equal(items.attr('length'), 1, 'order has 1 item');
+  ok(vm.attr('canPlaceOrder'), 'user can place the order');
+});
+
 asyncTest('Setting slug gets a restaurant and it is added to order', () => {
   let vm = new ViewModel({ slug: 'spago', '@root': new AppState() });
   let deferred = vm.attr('restaurant');


### PR DESCRIPTION
This implementation is slightly different from the one in the CanJS version, I did this because 

1) I wanted to be able to test it (no Funcunit tests)
2) If we go with disabling the button if no name/address/phone, it should be simpler to extend this.

- disabled state
![screen shot 2015-06-05 at 10 25 25](https://cloud.githubusercontent.com/assets/724877/8006853/b52a999a-0b6d-11e5-8e92-f70f5577bf71.png)

- enabled state
![screen shot 2015-06-05 at 10 25 36](https://cloud.githubusercontent.com/assets/724877/8006831/89cd0a6c-0b6d-11e5-99e7-1e0f2f75c552.png)

Let me know if you think we should keep the canjs version, or if I need to update that version to this code.

Closes #51.