### PR TITLE
Simplify the templates by using LESS

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -67,6 +67,11 @@ input[type="range"] {
   width: 100%;
 }
 
+// Make inputs inherit from form-control
+input[type="text"] {
+  .form-control;
+}
+
 // Make multiple select elements height not fixed
 select[multiple],
 select[size] {

--- a/less/homepage.less
+++ b/less/homepage.less
@@ -3,8 +3,9 @@
   .wrapper;
   padding: @grid-gutter-width !important;
   margin-bottom: @grid-gutter-width/2;
-  
-  .btn {
+
+  a[role="button"] {
+    .btn;
     .btn-primary;
     .btn-lg;
   }

--- a/less/list-group.less
+++ b/less/list-group.less
@@ -13,6 +13,10 @@
   padding-left: 0; // reset padding because ul and ol
 }
 
+// Inherit from list-group-item
+.list-group > li {
+  .list-group-item;
+}
 
 // Individual list items
 //

--- a/less/order-form.less
+++ b/less/order-form.less
@@ -5,6 +5,13 @@
   bit-panel {
     display: block;
     margin-top: 20px;
+
+    ul {
+      .list-group;
+    }
+    ul li {
+      &:extend(.list-group > li);
+    }
   }
 
   form {
@@ -28,7 +35,8 @@
   }
   .submit {
     .text-center;
-    .btn {
+    button[type="submit"] {
+      .btn;
       .btn-success; 
       font-size: @font-size-large;
     }

--- a/less/restaurants.less
+++ b/less/restaurants.less
@@ -47,6 +47,9 @@
         padding-right: 10px;
       }
     }
+    select {
+      .form-control;
+    }
   }
 }
 .open-now {

--- a/pmo/home.stache
+++ b/pmo/home.stache
@@ -2,5 +2,5 @@
   <img src="images/homepage-hero.jpg" width="250" height="380" />
   <h1>Ordering food has never been easier</h1>
   <p>We make it easier than ever to order gourmet food from your favorite local restaurants.</p>
-  <p><a class="btn" href="/restaurants" role="button">Choose a Restaurant</a></p>
+  <p><a href="/restaurants" role="button">Choose a Restaurant</a></p>
 </div>

--- a/pmo/order/phone/phone.component
+++ b/pmo/order/phone/phone.component
@@ -4,8 +4,8 @@
   </style>
   <template>
     <div class="form-group{{#if error}} has-error{{/if}}">
-      <label class="control-label">Phone:</label>
-      <input name="phone" type="text" class="form-control" can-keyup="{setPhoneValue @element.val}">
+      <label>Phone:</label>
+      <input name="phone" type="text" can-keyup="{setPhoneValue @element.val}">
       {{#if error}}
         {{#eq order.phone '911'}}
           <p>That's not your real number :-(</p>

--- a/pmo/restaurant/list/list.stache
+++ b/pmo/restaurant/list/list.stache
@@ -3,7 +3,7 @@
   <form class="form">
     <div class="form-group">
       <label>State</label>
-      <select class="form-control" can-value="{state}" {{#if states.isPending}}disabled{{/if}}>
+      <select can-value="{state}" {{#if states.isPending}}disabled{{/if}}>
         {{#if states.isPending}}
           <option value="">Loading...</option>
         {{else}}
@@ -18,7 +18,7 @@
     </div>
     <div class="form-group">
       <label>City</label>
-      <select class="form-control" can-value="city" {{^if state}}disabled{{/if}}>
+      <select can-value="city" {{^if state}}disabled{{/if}}>
         {{#if cities.isPending}}
           <option value="">Loading...</option>
         {{else}}


### PR DESCRIPTION
Goal is to remove some of the CSS cruft from the templates so they’re easier to read and are more focused on CanJS than what’s necessary to make the page look good.

Related to https://github.com/canjs/place-my-order/issues/4