### PR TITLE
Use a local API server on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node_modules/.bin/can-serve --proxy http://place-my-order.com/api
+web: node .server.js


### PR DESCRIPTION
This uses a local API server rather than proxying to the old api.