### PR TITLE
Eliminate missing key warning for scope.vm.action

### DIFF
--- a/src/order/history.component
+++ b/src/order/history.component
@@ -42,6 +42,7 @@
         listTitle:raw="Delivered"
         status:raw="delivered"
         statusTitle:raw="Delivered"
+        action:raw=""
         emptyMessage:raw="No delivered orders"/>
     </div>
   </view>

--- a/src/order/list.component
+++ b/src/order/list.component
@@ -21,14 +21,14 @@
 
         <div class="actions">
           <span class="badge">{{scope.vm.statusTitle}}</span>
-          {{#if(scope.vm.action)}}
+          {{^eq(scope.vm.action, '')}}
             <p class="action">
               Mark as:
               <a href="javascript://" on:click="markAs(scope.vm.action)">
                 {{scope.vm.actionTitle}}
               </a>
             </p>
-          {{/if}}
+          {{/eq}}
 
           <p class="action">
             <a href="javascript://" on:click="destroy()">Delete</a>


### PR DESCRIPTION
Otherwise, on the "Order History" page, completed orders cause a repeated unsightly warning:

`Unable to find key "scope.vm.action".`